### PR TITLE
Fixed issue w Track Torpedos being used as a mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ The holy gRail of minecart mods!
 
 ## Version Updates
 
+#### 0.6.701
+- Fixed a bug that would lock a player in if they attempted to mount/dismount from the Track Torpedo when equipped as a mount and used the mount hotkey.
+
 #### 0.6.7
 - Added compatibility for Necesse version 0.23.1
 

--- a/src/main/java/theholyrailmod/patch/MinecartMobPatch.java
+++ b/src/main/java/theholyrailmod/patch/MinecartMobPatch.java
@@ -7,7 +7,6 @@ import necesse.level.gameObject.GameObject;
 import net.bytebuddy.asm.Advice;
 import theholyrailmod.theholyrail.ChestMinecartMob;
 import theholyrailmod.theholyrail.PoweredRailObject;
-import theholyrailmod.theholyrail.RailRunnerMob;
 import theholyrailmod.theholyrail.StationTrackObject;
 import theholyrailmod.theholyrail.StationTrackObjectEntity;
 
@@ -40,10 +39,9 @@ public class MinecartMobPatch {
                 roleUnload = stationTrackEntity.getRoleUnload();
             }
 
-            RailRunnerMob rrMob = mobObject instanceof RailRunnerMob ? (RailRunnerMob) mobObject : null;
             ChestMinecartMob cmMob = mobObject instanceof ChestMinecartMob ? (ChestMinecartMob) mobObject : null;
 
-            if (!(mobObject instanceof RailRunnerMob) && !(mobObject instanceof ChestMinecartMob)) {
+            if (!(mobObject instanceof ChestMinecartMob)) {
                 if (trackObject instanceof PoweredRailObject) {
                     if (((PoweredRailObject) trackObject).isPowered(mobObject.getLevel(), tileX, tileY)
                             && rider != null) {
@@ -66,21 +64,7 @@ public class MinecartMobPatch {
             } else {
                 // Powered Track
                 if (trackObject instanceof PoweredRailObject) {
-                    if (mobObject instanceof RailRunnerMob) {
-                        if (((PoweredRailObject) trackObject).isPowered(mobObject.getLevel(), tileX, tileY)
-                                && rider != null) {
-                            mobObject.minecartSpeed = Math.min(rrMob.MAX_SPEED,
-                                    mobObject.minecartSpeed
-                                            + (rrMob.BOOST_SPEED * delta / 150.0f
-                                                    * mobObject.getAccelerationModifier()));
-                        } else if (rider == null) {
-                            mobObject.minecartSpeed = 0.0f;
-                        } else {
-                            mobObject.minecartSpeed = Math.max(0f,
-                                    mobObject.minecartSpeed > 12f ? (mobObject.minecartSpeed / 2.0f) * delta / 250.0f
-                                            : (mobObject.minecartSpeed - 0.1f) * delta / 250.0f);
-                        }
-                    } else if (mobObject instanceof ChestMinecartMob) {
+                    if (mobObject instanceof ChestMinecartMob) {
                         cmMob.setIsBeingStationed(false);
                         if (((PoweredRailObject) trackObject).isPowered(mobObject.getLevel(), tileX, tileY)) {
                             mobObject.minecartSpeed = Math.min(cmMob.MAX_SPEED,

--- a/src/main/java/theholyrailmod/patch/MinecartMountMobPatch.java
+++ b/src/main/java/theholyrailmod/patch/MinecartMountMobPatch.java
@@ -1,0 +1,77 @@
+package theholyrailmod.patch;
+
+import necesse.engine.modLoader.annotations.ModMethodPatch;
+import necesse.entity.mobs.Mob;
+import necesse.entity.mobs.summon.summonFollowingMob.mountFollowingMob.MinecartMountMob;
+import necesse.level.gameObject.GameObject;
+import net.bytebuddy.asm.Advice;
+import theholyrailmod.theholyrail.PoweredRailObject;
+import theholyrailmod.theholyrail.RailRunnerMob;
+import theholyrailmod.theholyrail.StationTrackObject;
+import theholyrailmod.theholyrail.StationTrackObjectEntity;
+
+public class MinecartMountMobPatch {
+    @ModMethodPatch(target = MinecartMountMob.class, name = "tickCollisionMovement", arguments = { float.class,
+            Mob.class })
+    public static class TickCollisionMovementPatch {
+        public static StationTrackObjectEntity stationTrackEntity;
+
+        @Advice.OnMethodEnter
+        public static void onEnter(@Advice.This MinecartMountMob mobObject,
+                @Advice.Argument(0) float delta,
+                @Advice.Argument(1) Mob rider) {
+            int tileX = mobObject.getTileX();
+            int tileY = mobObject.getTileY();
+            GameObject trackObject = mobObject.getLevel().getObject(tileX, tileY);
+
+            if (trackObject instanceof StationTrackObject) {
+                // set station track-specific variables
+                stationTrackEntity = (StationTrackObjectEntity) mobObject.getLevel().entityManager
+                        .getObjectEntity(tileX, tileY);
+            }
+
+            RailRunnerMob rrMob = mobObject instanceof RailRunnerMob ? (RailRunnerMob) mobObject : null;
+
+            if (!(mobObject instanceof RailRunnerMob)) {
+                if (trackObject instanceof PoweredRailObject) {
+                    if (((PoweredRailObject) trackObject).isPowered(mobObject.getLevel(), tileX, tileY)
+                            && rider != null) {
+                        float MAX_SPEED = 200.0f;
+                        float BOOST_SPEED = MAX_SPEED * 4.5f;
+                        mobObject.minecartSpeed = Math.min(MAX_SPEED,
+                                mobObject.minecartSpeed
+                                        + (BOOST_SPEED * delta / 150.0f
+                                                * mobObject.getAccelerationModifier()));
+                    } else if (rider == null) {
+                        mobObject.minecartSpeed = 0.0f;
+                    } else {
+                        mobObject.minecartSpeed = Math.min(0f,
+                                mobObject.minecartSpeed > 4f ? (mobObject.minecartSpeed / 2.0f) * delta / 250.0f
+                                        : mobObject.minecartSpeed > 0f
+                                                ? (mobObject.minecartSpeed - 0.01f) * delta / 250.0f
+                                                : 0f);
+                    }
+                }
+            } else {
+                // Powered Track
+                if (trackObject instanceof PoweredRailObject) {
+                    if (mobObject instanceof RailRunnerMob) {
+                        if (((PoweredRailObject) trackObject).isPowered(mobObject.getLevel(), tileX, tileY)
+                                && rider != null) {
+                            mobObject.minecartSpeed = Math.min(rrMob.MAX_SPEED,
+                                    mobObject.minecartSpeed
+                                            + (rrMob.BOOST_SPEED * delta / 150.0f
+                                                    * mobObject.getAccelerationModifier()));
+                        } else if (rider == null) {
+                            mobObject.minecartSpeed = 0.0f;
+                        } else {
+                            mobObject.minecartSpeed = Math.max(0f,
+                                    mobObject.minecartSpeed > 12f ? (mobObject.minecartSpeed / 2.0f) * delta / 250.0f
+                                            : (mobObject.minecartSpeed - 0.1f) * delta / 250.0f);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/theholyrailmod/theholyrail/RailRunnerMob.java
+++ b/src/main/java/theholyrailmod/theholyrail/RailRunnerMob.java
@@ -15,20 +15,17 @@ import necesse.entity.mobs.MobDrawable;
 import necesse.entity.mobs.PlayerMob;
 import necesse.entity.mobs.summon.MinecartLinePos;
 import necesse.entity.mobs.summon.MinecartLines;
-import necesse.entity.mobs.summon.MinecartMob;
+import necesse.entity.mobs.summon.summonFollowingMob.mountFollowingMob.MinecartMountMob;
 import necesse.gfx.camera.GameCamera;
 import necesse.gfx.drawOptions.DrawOptions;
 import necesse.gfx.drawables.OrderableDrawables;
 import necesse.gfx.gameTexture.GameTexture;
-import necesse.inventory.lootTable.LootTable;
-import necesse.inventory.lootTable.lootItem.LootItem;
 import necesse.level.gameObject.GameObject;
 import necesse.level.gameObject.MinecartTrackObject;
 import necesse.level.maps.Level;
 import necesse.level.maps.light.GameLight;
 
-public class RailRunnerMob extends MinecartMob {
-   public static LootTable lootTable = new LootTable(new LootItem("railrunner"));
+public class RailRunnerMob extends MinecartMountMob {
    public static GameTexture texture;
    public float collisionMovementBuffer;
    public Point collisionMovementLastPos;
@@ -39,7 +36,7 @@ public class RailRunnerMob extends MinecartMob {
    protected float breakParticleBuffer;
    protected boolean breakParticleAlternate;
 
-   // vars used by the MinecartMobPatch
+   // vars used by the MinecartMountMobPatch
    public final float MAX_SPEED = 265.0f;
    public final float BOOST_SPEED = MAX_SPEED * 5;
    // ----------------------------------------------
@@ -76,11 +73,6 @@ public class RailRunnerMob extends MinecartMob {
       super.applyMovementPacket(reader, isDirect);
       this.railRunnerSpeed = reader.getNextFloat();
       this.railRunnerDir = reader.getNextMaxValue(3);
-   }
-
-   @Override
-   public LootTable getLootTable() {
-      return lootTable;
    }
 
    @Override

--- a/src/main/java/theholyrailmod/theholyrail/RailRunnerMountItem.java
+++ b/src/main/java/theholyrailmod/theholyrail/RailRunnerMountItem.java
@@ -3,6 +3,8 @@ package theholyrailmod.theholyrail;
 import necesse.engine.Screen;
 import necesse.engine.localization.Localization;
 import necesse.engine.network.PacketReader;
+import necesse.engine.network.packet.PacketMobMount;
+import necesse.engine.network.server.FollowPosition;
 import necesse.engine.network.server.ServerClient;
 import necesse.engine.registries.ItemRegistry;
 import necesse.engine.registries.MobRegistry;
@@ -11,6 +13,7 @@ import necesse.entity.mobs.Mob;
 import necesse.entity.mobs.PlayerMob;
 import necesse.entity.mobs.summon.MinecartLinePos;
 import necesse.entity.mobs.summon.MinecartLines;
+import necesse.entity.mobs.summon.summonFollowingMob.mountFollowingMob.MountFollowingMob;
 import necesse.gfx.GameResources;
 import necesse.gfx.camera.GameCamera;
 import necesse.gfx.drawOptions.itemAttack.ItemAttackDrawOptions;
@@ -21,6 +24,7 @@ import necesse.inventory.PlayerInventorySlot;
 import necesse.inventory.item.mountItem.MountItem;
 import necesse.level.gameObject.GameObject;
 import necesse.level.gameObject.MinecartTrackObject;
+import necesse.level.gameObject.TrapTrackObject;
 import necesse.level.maps.Level;
 
 public class RailRunnerMountItem extends MountItem implements PlaceableItemInterface {
@@ -51,7 +55,8 @@ public class RailRunnerMountItem extends MountItem implements PlaceableItemInter
 
             for (int tileX = playerTileX - 1; tileX <= playerTileX + 1; ++tileX) {
                for (int tileY = playerTileY - 1; tileY <= playerTileY + 1; ++tileY) {
-                  if (level.getObject(tileX, tileY) instanceof MinecartTrackObject) {
+                  GameObject object = level.getObject(tileX, tileY);
+                  if (object instanceof MinecartTrackObject && !(object instanceof TrapTrackObject)) {
                      return null;
                   }
                }
@@ -73,9 +78,10 @@ public class RailRunnerMountItem extends MountItem implements PlaceableItemInter
 
       for (int tileX = playerTileX - 1; tileX <= playerTileX + 1; ++tileX) {
          for (int tileY = playerTileY - 1; tileY <= playerTileY + 1; ++tileY) {
-            if (level.getObject(tileX, tileY) instanceof MinecartTrackObject) {
-               MinecartLines lines = ((MinecartTrackObject) level.getObject(tileX, tileY)).getMinecartLines(level,
-                     tileX, tileY, 0.0F, 0.0F, false);
+            GameObject object = level.getObject(tileX, tileY);
+            if (object instanceof MinecartTrackObject && !(object instanceof TrapTrackObject)) {
+               MinecartLines lines = ((MinecartTrackObject) object).getMinecartLines(level, tileX, tileY, 0.0F, 0.0F,
+                     false);
                MinecartLinePos pos = lines.getMinecartPos(player.x, player.y, player.dir);
                if (pos != null) {
                   float distance = player.getDistance(pos.x, pos.y);
@@ -154,7 +160,7 @@ public class RailRunnerMountItem extends MountItem implements PlaceableItemInter
             }
 
             GameObject object = level.getObject(mob.getTileX(), mob.getTileY());
-            if (!(object instanceof MinecartTrackObject)) {
+            if (!(object instanceof MinecartTrackObject) || object instanceof TrapTrackObject) {
                return "nottracks";
             }
          }


### PR DESCRIPTION
Fixed a bug that would lock a player in if they attempted to mount/dismount from the Track Torpedo when equipped as a mount and used the mount hotkey.